### PR TITLE
Add irb to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 
 gem "standard", "~> 1.3"
+
+gem "irb", "~> 1.15.1"

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,4 @@ gem "rspec", "~> 3.0"
 
 gem "standard", "~> 1.3"
 
-gem "irb", "~> 1.15.1"
+gem "irb"


### PR DESCRIPTION
Resolve this warning

```
bin/console:10: warning: irb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add irb to your Gemfile or gemspec to silence this warning.
```