### PR TITLE
Require missing library

### DIFF
--- a/lib/nero.rb
+++ b/lib/nero.rb
@@ -6,6 +6,7 @@ loader.setup
 
 require "uri" # why needed?
 require "yaml"
+require "pathname"
 
 # TODO fail on unknown tag
 # TODO show missing env's at once


### PR DESCRIPTION
When running `rake spec` it fails cause can not find `Pathname`.

Try it

foo.rb
```
Pathname
```
$ ruby foo.rb
and then

bar.rb
```
require "pathname"
Pathname
```

I don't know why, but when you run `irb` Pathname is already required.